### PR TITLE
Add help hints

### DIFF
--- a/config.php
+++ b/config.php
@@ -31,17 +31,17 @@ set_time_limit(60);
 if (!file_exists($ROSDir))
 {
     echo "ReactOS source path <b>$ROSDir</b> does not exist!";
-	if (strpos($uname, "linux") !== false)
-	{
-		echo "<br><br>For <b><u>Linux users</u></b>: make sure you have set the right permission rights for both the ReactOS source code directory and the tool directory.   Use <i>chmod</i> command and set their rights to 755 for both these directories if necessary. In any case you're using XAMPP for Linux, change the user and usergroup to yours. To do so read this: <a href = 'https://askubuntu.com/a/221593'>Change XAMPP's usergroup and username (link)</a>";
-	} 
-	elseif (strpos($uname, "win") !== false)
-	{
-		echo "<br><br>For <b><u>Windows users</u></b>: make sure the ReactOS source code path is <b>CORRECT</b> or that it is not <b>CORRUPT</b>";
-	}
+    if (strpos($uname, "linux") !== false)
+    {
+        echo "<br><br>For <b><u>Linux users</u></b>: make sure you have set the right permission rights for both the ReactOS source code directory and the tool directory. Use <i>chmod</i> command and set their rights to 755 for both these directories if necessary. In any case you're using XAMPP for Linux, change the user and usergroup to yours. To do so read this: <a href='https://askubuntu.com/a/221593'>Change XAMPP's usergroup and username (link)</a>";
+    }
+    elseif (strpos($uname, "win") !== false)
+    {
+        echo "<br><br>For <b><u>Windows users</u></b>: make sure the ReactOS source code path is <b>CORRECT</b> or that it is not <b>CORRUPT</b>";
+    }
     exit;
 }
 
 if (substr($ROSDir, -1) !== DIRECTORY_SEPARATOR) {
-	$ROSDir .= DIRECTORY_SEPARATOR;
+    $ROSDir .= DIRECTORY_SEPARATOR;
 }

--- a/config.php
+++ b/config.php
@@ -1,4 +1,7 @@
 <?php
+// DO NOT touch this variable! php_uname() returns the type of the OS as string!
+$uname = strtolower(php_uname());
+
 // ReactOS Source directory - must contain the base and dll directories
 $ROSDir = 'E:/ReactOS';
 
@@ -28,6 +31,14 @@ set_time_limit(60);
 if (!file_exists($ROSDir))
 {
     echo "ReactOS source path <b>$ROSDir</b> does not exist!";
+	if (strpos($uname, "linux") !== false)
+	{
+		echo "<br><br>For <b><u>Linux users</u></b>: make sure you have set the right permission rights for both the ReactOS source code directory and the tool directory.   Use <i>chmod</i> command and set their rights to 755 for both these directories if necessary. In any case you're using XAMPP for Linux, change the user and usergroup to yours. To do so read this: <a href = 'https://askubuntu.com/a/221593'>Change XAMPP's usergroup and username (link)</a>";
+	}
+	else if (strpos($uname, "win") !== false)
+	{
+		echo "<br><br>For <b><u>Windows users</u></b>: make sure the ReactOS source code path is <b>CORRECT</b> or that it is not <b>CORRUPT</b>";
+	}
     exit;
 }
 

--- a/config.php
+++ b/config.php
@@ -34,8 +34,7 @@ if (!file_exists($ROSDir))
 	if (strpos($uname, "linux") !== false)
 	{
 		echo "<br><br>For <b><u>Linux users</u></b>: make sure you have set the right permission rights for both the ReactOS source code directory and the tool directory.   Use <i>chmod</i> command and set their rights to 755 for both these directories if necessary. In any case you're using XAMPP for Linux, change the user and usergroup to yours. To do so read this: <a href = 'https://askubuntu.com/a/221593'>Change XAMPP's usergroup and username (link)</a>";
-	}
-	else if (strpos($uname, "win") !== false)
+	} elseif (strpos($uname, "win") !== false)
 	{
 		echo "<br><br>For <b><u>Windows users</u></b>: make sure the ReactOS source code path is <b>CORRECT</b> or that it is not <b>CORRUPT</b>";
 	}

--- a/config.php
+++ b/config.php
@@ -34,7 +34,8 @@ if (!file_exists($ROSDir))
 	if (strpos($uname, "linux") !== false)
 	{
 		echo "<br><br>For <b><u>Linux users</u></b>: make sure you have set the right permission rights for both the ReactOS source code directory and the tool directory.   Use <i>chmod</i> command and set their rights to 755 for both these directories if necessary. In any case you're using XAMPP for Linux, change the user and usergroup to yours. To do so read this: <a href = 'https://askubuntu.com/a/221593'>Change XAMPP's usergroup and username (link)</a>";
-	} elseif (strpos($uname, "win") !== false)
+	} 
+	elseif (strpos($uname, "win") !== false)
 	{
 		echo "<br><br>For <b><u>Windows users</u></b>: make sure the ReactOS source code path is <b>CORRECT</b> or that it is not <b>CORRUPT</b>";
 	}


### PR DESCRIPTION
# Purpose & Implementations

To avoid any further doubts or problems in the fore future (mostly Linux users), a few hints were added to help the user in case of a failure regarding _"ReactOS source could not be found!"_.